### PR TITLE
Add sdf utilities to get NMF_TEMPLATE and BOUNDS

### DIFF
--- a/examples/example_entire_pipeline.py
+++ b/examples/example_entire_pipeline.py
@@ -17,7 +17,7 @@ from seqikpy.kinematic_chain import KinematicChainSeq
 from seqikpy.leg_inverse_kinematics import LegInvKinSeq
 from seqikpy.head_inverse_kinematics import HeadInverseKinematics
 from seqikpy.data import BOUNDS, INITIAL_ANGLES, NMF_TEMPLATE, PTS2ALIGN
-from seqikpy.utils import save_file
+from seqikpy.utils import save_file, from_sdf
 
 logging.basicConfig(
     format=" %(asctime)s - %(levelname)s- %(message)s",
@@ -42,6 +42,11 @@ def parse_args():
         action="store_true",
         help="Plot the joint angles.",
     )
+    parser.add_argument(
+        "--sdf",
+        default=None,
+        help="SDF path for the template model.",
+    )
     return parser.parse_args()
 
 
@@ -54,6 +59,11 @@ if __name__ == "__main__":
 
     paths = Path(path_name).rglob("pose-3d")
 
+    if args.sdf:
+        sdf_name = args.sdf
+        sdf_name += "/" if not sdf_name.endswith("/") else ""
+        NMF_TEMPLATE, BOUNDS = from_sdf(sdf_name)
+        
     for data_path in paths:
 
         logging.info("Running code in %s", data_path)

--- a/examples/example_entire_pipeline.py
+++ b/examples/example_entire_pipeline.py
@@ -5,6 +5,7 @@
     Example usage:
 
     >>> python example_entire_pipeline.py -p ../data/anipose_220525_aJO_Fly001_001 --plot
+
 """
 import logging
 from pathlib import Path
@@ -42,11 +43,6 @@ def parse_args():
         action="store_true",
         help="Plot the joint angles.",
     )
-    parser.add_argument(
-        "--sdf",
-        default=None,
-        help="SDF path for the template model.",
-    )
     return parser.parse_args()
 
 
@@ -59,11 +55,6 @@ if __name__ == "__main__":
 
     paths = Path(path_name).rglob("pose-3d")
 
-    if args.sdf:
-        sdf_name = args.sdf
-        sdf_name += "/" if not sdf_name.endswith("/") else ""
-        NMF_TEMPLATE, BOUNDS = from_sdf(sdf_name)
-        
     for data_path in paths:
 
         logging.info("Running code in %s", data_path)

--- a/examples/example_leg_inv_kinematics.py
+++ b/examples/example_leg_inv_kinematics.py
@@ -2,6 +2,7 @@
     Example usage of leg inverse kinematics module.
     Note that running this script will take about 30 minutes.
 """
+
 import time
 from pathlib import Path
 
@@ -10,15 +11,21 @@ import matplotlib.pyplot as plt
 from seqikpy.kinematic_chain import KinematicChainSeq, KinematicChainGeneric
 from seqikpy.leg_inverse_kinematics import LegInvKinSeq, LegInvKinGeneric
 from seqikpy.data import BOUNDS, INITIAL_ANGLES
-from seqikpy.utils import load_file
+from seqikpy.utils import load_file, from_sdf, calculate_body_size
 
 
-DATA_PATH = Path('../data/anipose_220525_aJO_Fly001_001/pose-3d')
+DATA_PATH = Path("../data/anipose_220525_aJO_Fly001_001/pose-3d")
 
 
 f_path = DATA_PATH / "pose3d_aligned.pkl"
 
 aligned_pos = load_file(f_path)
+
+LOAD_FROM_SDF = True
+# If you want to load the template from an sdf file
+if LOAD_FROM_SDF:
+    sdf_path = Path("../tests/nmf_example.sdf")
+    NMF_TEMPLATE, BOUNDS = from_sdf(sdf_path)
 
 start = time.time()
 
@@ -28,20 +35,19 @@ seq_ik = LegInvKinSeq(
     kinematic_chain_class=KinematicChainSeq(
         bounds_dof=BOUNDS,
         legs_list=["RF"],
-        body_size=None,
+        body_size=calculate_body_size(NMF_TEMPLATE),
     ),
-    initial_angles=INITIAL_ANGLES
+    initial_angles=INITIAL_ANGLES,
 )
 
 leg_joint_angles_seq, forward_kinematics_seq = seq_ik.run_ik_and_fk(
-    export_path=DATA_PATH,
-    hide_progress_bar=True
+    export_path=DATA_PATH, hide_progress_bar=True
 )
 
 end = time.time()
 total_time = (end - start) / 60.0
 
-print(f'Sequential IK took {total_time} mins')
+print(f"Sequential IK took {total_time} mins")
 
 start = time.time()
 
@@ -53,29 +59,28 @@ gen_ik = LegInvKinGeneric(
         legs_list=["RF"],
         body_size=None,
     ),
-    initial_angles=INITIAL_ANGLES
+    initial_angles=INITIAL_ANGLES,
 )
 
 leg_joint_angles_gen, forward_kinematics_gen = gen_ik.run_ik_and_fk(
-    export_path=DATA_PATH,
-    hide_progress_bar=True
+    export_path=DATA_PATH, hide_progress_bar=True
 )
 
 end = time.time()
 total_time = (end - start) / 60.0
 
-print(f'Traditional IK took {total_time} mins')
+print(f"Traditional IK took {total_time} mins")
 
 # Compare the joint angles
 fig, ax = plt.subplots(1, 1, figsize=(10, 5))
 for key in leg_joint_angles_seq:
     plt.plot(leg_joint_angles_seq[key], label=key[6:], lw=2)
-    plt.plot(leg_joint_angles_gen[key], ls=':', lw=2)
+    plt.plot(leg_joint_angles_gen[key], ls=":", lw=2)
 
 
-plt.xlabel('Frames (AU)')
-plt.ylabel('Angles (rad)')
-plt.title('Leg joint angles from SeqIK (solid) and GenIK (dotted)')
+plt.xlabel("Frames (AU)")
+plt.ylabel("Angles (rad)")
+plt.title("Leg joint angles from SeqIK (solid) and GenIK (dotted)")
 plt.legend()
 plt.grid(True)
 plt.show()

--- a/examples/example_leg_inv_kinematics.py
+++ b/examples/example_leg_inv_kinematics.py
@@ -34,7 +34,7 @@ seq_ik = LegInvKinSeq(
     aligned_pos=aligned_pos,
     kinematic_chain_class=KinematicChainSeq(
         bounds_dof=BOUNDS,
-        legs_list=["RF"],
+        legs_list=["RF", "LF"],
         body_size=calculate_body_size(NMF_TEMPLATE),
     ),
     initial_angles=INITIAL_ANGLES,
@@ -56,7 +56,7 @@ gen_ik = LegInvKinGeneric(
     aligned_pos=aligned_pos,
     kinematic_chain_class=KinematicChainGeneric(
         bounds_dof=BOUNDS,
-        legs_list=["RF"],
+        legs_list=["RF", "LF"],
         body_size=None,
     ),
     initial_angles=INITIAL_ANGLES,

--- a/seqikpy/utils.py
+++ b/seqikpy/utils.py
@@ -1,4 +1,5 @@
 """ Utilities. """
+
 from pathlib import Path
 import logging
 from typing import Dict, List
@@ -11,15 +12,16 @@ import xml
 import xml.etree.ElementTree as ET
 import numpy as np
 
+
 def get_fps_from_video(video_dir):
-    """ Finds the fps of a video. """
+    """Finds the fps of a video."""
     cap = cv2.VideoCapture(str(video_dir))
     fps = int(cap.get(cv2.CAP_PROP_FPS))
     return fps
 
 
 def load_stim_data(main_dir: Path):
-    """ Loads the stimulus info from txt."""
+    """Loads the stimulus info from txt."""
     stim_dir = main_dir / "stimulusSequence.txt"
 
     try:
@@ -32,12 +34,13 @@ def load_stim_data(main_dir: Path):
 
 
 def get_stim_array(
-        lines: list,
-        frame_rate: int,
-        scale: int = 1,
-        hamming_window_size: int = 0,
-        time_scale: int = 1e-3):
-    """ Computes a stimulus array from the stimulus information.
+    lines: list,
+    frame_rate: int,
+    scale: int = 1,
+    hamming_window_size: int = 0,
+    time_scale: int = 1e-3,
+):
+    """Computes a stimulus array from the stimulus information.
 
     Parameters
     ----------
@@ -65,19 +68,21 @@ def get_stim_array(
     start = 0
     for repeat_no in range(repeat):
         for line_no in range(2, len(lines) - 1):
-            duration = int(int(lines[line_no].split()[-1])
-                           * frame_rate * time_scale * scale)
-            stim_array[start:start +
-                       duration] = False if lines[line_no].startswith("off") else True
+            duration = int(
+                int(lines[line_no].split()[-1]) * frame_rate * time_scale * scale
+            )
+            stim_array[start : start + duration] = (
+                False if lines[line_no].startswith("off") else True
+            )
             start += duration
 
     trim_ind = int(hamming_window_size * 0.5)
-    return stim_array[trim_ind: stim_array.shape[0] - trim_ind]
+    return stim_array[trim_ind : stim_array.shape[0] - trim_ind]
 
 
 def get_stim_intervals(stim_data):
-    """ Reads stimulus array and returns the stim intervals for plotting purposes.
-    Use get_stim_array otherwise. """
+    """Reads stimulus array and returns the stim intervals for plotting purposes.
+    Use get_stim_array otherwise."""
     stim_on = np.where(stim_data)[0]
     stim_start_end = [stim_on[0]]
     for ind in list(np.where(np.diff(stim_on) > 1)[0]):
@@ -93,7 +98,7 @@ def calculate_body_size(
     body_template: Dict[str, np.ndarray],
     legs_list: List[str] = ["RF", "LF", "RM", "LM", "RH", "LH"],
 ) -> Dict[str, np.ndarray]:
-    """ Calculates body segment sizes from the template data."""
+    """Calculates body segment sizes from the template data."""
     if set(legs_list).difference(set(["RF", "LF", "RM", "LM", "RH", "LH"])):
         raise NameError(
             f"""
@@ -106,36 +111,43 @@ def calculate_body_size(
 
     for i, segment_name in enumerate(leg_segments):
         for leg in legs_list:
-            # If Claw, calculate the length of the entire leg
+            # If Claw, calculate the length of the entire leg
             if segment_name == "Claw":
-                body_size[leg] = body_size[f"{leg}_Coxa"] + body_size[f"{leg}_Femur"] + \
-                    body_size[f"{leg}_Tibia"] + body_size[f"{leg}_Tarsus"]
+                body_size[leg] = (
+                    body_size[f"{leg}_Coxa"]
+                    + body_size[f"{leg}_Femur"]
+                    + body_size[f"{leg}_Tibia"]
+                    + body_size[f"{leg}_Tarsus"]
+                )
             else:
                 body_size[f"{leg}_{segment_name}"] = np.linalg.norm(
-                    body_template[f"{leg}_{segment_name}"] -
-                    body_template[f"{leg}_{leg_segments[i+1]}"]
+                    body_template[f"{leg}_{segment_name}"]
+                    - body_template[f"{leg}_{leg_segments[i+1]}"]
                 )
-    # Assuming right and left hand-side are symmetric, checking for one side is enough
+    # Assuming right and left hand-side are symmetric, checking for one side is enough
     if "R_Antenna_base" in body_template:
         body_size["Antenna"] = np.linalg.norm(
-            body_template["R_Antenna_base"] -
-            body_template["R_Antenna_edge"])
+            body_template["R_Antenna_base"] - body_template["R_Antenna_edge"]
+        )
         body_size["Antenna_mid_thorax"] = np.linalg.norm(
-            body_template["R_Antenna_base"] - body_template["Thorax_mid"])
+            body_template["R_Antenna_base"] - body_template["Thorax_mid"]
+        )
 
     return body_size
 
 
 def drop_level_dlc(data_frame):
-    """ Converts DLC type dataframe into one level df. """
+    """Converts DLC type dataframe into one level df."""
     data_frame.columns = data_frame.columns.droplevel()
     data_frame.columns = ["_".join(col) for col in data_frame.columns.values]
 
     return data_frame
 
 
-def fix_coxae_pos(points3d, right_coxa_kp="thorax_coxa_R", left_coxa_kp="thorax_coxa_L"):
-    """ Calculates the fixed coxae location based on the quantiles. """
+def fix_coxae_pos(
+    points3d, right_coxa_kp="thorax_coxa_R", left_coxa_kp="thorax_coxa_L"
+):
+    """Calculates the fixed coxae location based on the quantiles."""
     coxa_right = get_array(right_coxa_kp, points3d)
     coxa_left = get_array(left_coxa_kp, points3d)
     coxa_right_fixed = (
@@ -165,7 +177,7 @@ def leg_length_model(nmf_size: dict, leg_name: str, claw_is_ee: bool):
 
 
 def get_length_of_segments(points3d, claw_is_ee=False):
-    """ Returns a dictionary with segment sizes. """
+    """Returns a dictionary with segment sizes."""
     segments = {
         "Coxa": ("thorax_coxa", "coxa_femur"),
         "Femur": ("coxa_femur", "femur_tibia"),
@@ -184,7 +196,7 @@ def get_length_of_segments(points3d, claw_is_ee=False):
 
 
 def compute_mean_length_of_segments(segment_lengths):
-    """Computes mean length of each segment. """
+    """Computes mean length of each segment."""
     mean_segment_length = {}
     for segment, length_array in segment_lengths.items():
         mean_segment_length[segment] = np.mean(length_array)
@@ -193,13 +205,13 @@ def compute_mean_length_of_segments(segment_lengths):
 
 
 def get_mean_length_of_segments(points3d):
-    """ Gets a dictionary with segment lengths. """
+    """Gets a dictionary with segment lengths."""
     lengths = get_length_of_segments(points3d)
     return compute_mean_length_of_segments(lengths)
 
 
 def get_leg_length(mean_segment_size):
-    """ Returns the leg size from the mean segment lengths."""
+    """Returns the leg size from the mean segment lengths."""
     leg_length_r = np.sum(
         [size for name, size in mean_segment_size.items() if "R_" in name]
     )
@@ -223,7 +235,8 @@ def get_array(kp_name, kp_dict):
 
 def get_mean_quantile(vector, quantile_diff=0.05):
     return 0.5 * (
-        np.quantile(vector, q=0.5 - quantile_diff) + np.quantile(vector, q=0.5 + quantile_diff)
+        np.quantile(vector, q=0.5 - quantile_diff)
+        + np.quantile(vector, q=0.5 + quantile_diff)
     )
 
 
@@ -270,23 +283,22 @@ def from_anipose_to_array(points3d, claw_is_end_effector=False):
 
 
 def df_to_nparray(data_frame, side, claw_is_end_effector, segment="F"):
-    """ Convert usual dataframe format into a three dimensional array. """
+    """Convert usual dataframe format into a three dimensional array."""
     if claw_is_end_effector:
         key_points = ["Coxa", "Femur", "Tibia", "Tarsus", "Claw"]
     else:
         key_points = ["Coxa", "Femur", "Tibia", "Tarsus"]
 
     position_array = np.empty(
-        (data_frame[f"Pose_{side}F_Coxa_x"].shape[0],
-         len(key_points),
-         3))  # timestep, key points, axes
+        (data_frame[f"Pose_{side}F_Coxa_x"].shape[0], len(key_points), 3)
+    )  # timestep, key points, axes
 
     for i, kp in enumerate(key_points):
         position_array[:, i, :] = np.array(
             [
                 data_frame[f"Pose_{side}{segment}_{kp}_x"].to_numpy(),
                 data_frame[f"Pose_{side}{segment}_{kp}_y"].to_numpy(),
-                data_frame[f"Pose_{side}{segment}_{kp}_z"].to_numpy()
+                data_frame[f"Pose_{side}{segment}_{kp}_z"].to_numpy(),
             ]
         )
 
@@ -294,7 +306,7 @@ def df_to_nparray(data_frame, side, claw_is_end_effector, segment="F"):
 
 
 def dict_to_nparray_pose(pose_dict, claw_is_end_effector):
-    """ Convert usual df3dPP dictionary format into a three dimensional array. """
+    """Convert usual df3dPP dictionary format into a three dimensional array."""
 
     if claw_is_end_effector:
         key_points = ["Coxa", "Femur", "Tibia", "Tarsus", "Claw"]
@@ -302,71 +314,117 @@ def dict_to_nparray_pose(pose_dict, claw_is_end_effector):
         key_points = ["Coxa", "Femur", "Tibia", "Tarsus"]
 
     position_array = np.empty(
-        (pose_dict["Coxa"]["raw_pos_aligned"].shape[0],
-         len(key_points),
-         3))  # timestep, key points, axes
+        (pose_dict["Coxa"]["raw_pos_aligned"].shape[0], len(key_points), 3)
+    )  # timestep, key points, axes
 
     for i, kp in enumerate(key_points):
-        position_array[:, i, :] = np.array(
-            pose_dict[kp]["raw_pos_aligned"])
+        position_array[:, i, :] = np.array(pose_dict[kp]["raw_pos_aligned"])
 
     return position_array
 
 
 def dict_to_nparray_angle(angle_dict, leg, claw_is_end_effector):
-    """ Convert usual df3dPP dictionary format into a three dimensional array. """
+    """Convert usual df3dPP dictionary format into a three dimensional array."""
 
     if claw_is_end_effector:
-        dofs = ["ThC_roll", "ThC_yaw", "ThC_pitch", "CTr_pitch", "CTr_roll", "FTi_pitch", "TiTa_pitch"]
+        dofs = [
+            "ThC_roll",
+            "ThC_yaw",
+            "ThC_pitch",
+            "CTr_pitch",
+            "CTr_roll",
+            "FTi_pitch",
+            "TiTa_pitch",
+        ]
     else:
-        dofs = ["ThC_roll", "ThC_yaw", "ThC_pitch", "CTr_pitch", "CTr_roll", "FTi_pitch"]
+        dofs = [
+            "ThC_roll",
+            "ThC_yaw",
+            "ThC_pitch",
+            "CTr_pitch",
+            "CTr_roll",
+            "FTi_pitch",
+        ]
 
     angle_array = np.empty(
-        (len(angle_dict[f"{leg}_leg"][dofs[0]]),
-         len(dofs)))  # timestep, dofs
+        (len(angle_dict[f"{leg}_leg"][dofs[0]]), len(dofs))
+    )  # timestep, dofs
 
     for i, kp in enumerate(dofs):
-        angle_array[:, i, ] = np.array(
-            angle_dict[f"{leg}_leg"][kp])
+        angle_array[
+            :,
+            i,
+        ] = np.array(angle_dict[f"{leg}_leg"][kp])
 
     return angle_array
 
 
 def interpolate_signal(signal, original_ts, new_ts):
-    """ Interpolates signals. """
+    """Interpolates signals."""
     total_time = signal.shape[0] * original_ts
     original_x = np.arange(0, total_time, original_ts)
     new_x = np.arange(0, total_time, new_ts)
 
     try:
-        interpolated = np.array(
-            pchip_interpolate(original_x, signal, new_x)
-        )
+        interpolated = np.array(pchip_interpolate(original_x, signal, new_x))
     except BaseException:
         signal[np.isinf(signal)] = 0
         signal[-1] = 0
-        interpolated = np.array(
-            pchip_interpolate(original_x, signal, new_x)
-        )
+        interpolated = np.array(pchip_interpolate(original_x, signal, new_x))
 
     return interpolated
 
 
 def interpolate_joint_angles(joint_angles_dict, **kwargs):
-    """ Interpolates joint angles. """
+    """Interpolates joint angles."""
     interpolated_joint_angles = {}
 
     for dof in joint_angles_dict:
-        interpolated_joint_angles[dof] = interpolate_signal(signal=joint_angles_dict[dof], **kwargs)
+        interpolated_joint_angles[dof] = interpolate_signal(
+            signal=joint_angles_dict[dof], **kwargs
+        )
 
     return interpolated_joint_angles
 
-def from_sdf(sdf_file):
+
+def from_sdf(sdf_file: str):
+    """Extracts a body template and joint bounds from an SDF file.
+
+    Parameters
+    ----------
+    sdf_file : str
+        Path to the SDF file.
+
+    Returns
+    -------
+    Dict, Dict
+        Body template and joint bounds.
+    """
+    # Parse the SDF file
     sdf_in = ET.parse(sdf_file)
     root_in = sdf_in.getroot()
-    model_in = root_in.find('world').find('model')
-    links = model_in.findall('link')
-    joints = model_in.findall('joint')
-    NMF_TEMPLATE = {link.attrib['name']:link.find('pose').text for link in links}
-    BOUNDS = {joint.attrib['name']:(joint.find('axis').find('limit').find('lower').text,joint.find('axis').find('limit').find('upper').text) for joint in joints}
-    return NMF_TEMPLATE, BOUNDS
+    model_in = root_in.find("world").find("model")
+    # Get links and joints
+    links = model_in.findall("link")
+    joints = model_in.findall("joint")
+    # Extract the body template
+    body_template = {}
+    for link in links:
+        if not any(dof in link.attrib["name"] for dof in ["roll", "pitch", "yaw"]):
+            # Get location of the joint
+            joint_loc_str = link.find("pose").text
+            # Convert string into a numpy array
+            joint_loc = np.array([float(val) for val in joint_loc_str.split(" ")])
+            # Get only the x, y, z coordinates
+            body_template[link.attrib["name"]] = joint_loc[:3]
+
+    # Extract the joint bounds
+    joint_bounds = {
+        joint.attrib["name"]: (
+            float(joint.find("axis").find("limit").find("lower").text),
+            float(joint.find("axis").find("limit").find("upper").text),
+        )
+        for joint in joints
+
+    }
+    return body_template, joint_bounds

--- a/seqikpy/utils.py
+++ b/seqikpy/utils.py
@@ -7,6 +7,9 @@ import numpy as np
 import cv2
 from scipy.interpolate import pchip_interpolate
 
+import xml
+import xml.etree.ElementTree as ET
+import numpy as np
 
 def get_fps_from_video(video_dir):
     """ Finds the fps of a video. """
@@ -357,3 +360,13 @@ def interpolate_joint_angles(joint_angles_dict, **kwargs):
         interpolated_joint_angles[dof] = interpolate_signal(signal=joint_angles_dict[dof], **kwargs)
 
     return interpolated_joint_angles
+
+def from_sdf(sdf_file):
+    sdf_in = ET.parse(sdf_file)
+    root_in = sdf_in.getroot()
+    model_in = root_in.find('world').find('model')
+    links = model_in.findall('link')
+    joints = model_in.findall('joint')
+    NMF_TEMPLATE = {link.attrib['name']:link.find('pose').text for link in links}
+    BOUNDS = {joint.attrib['name']:(joint.find('axis').find('limit').find('lower').text,joint.find('axis').find('limit').find('upper').text) for joint in joints}
+    return NMF_TEMPLATE, BOUNDS

--- a/tests/nmf_example.sdf
+++ b/tests/nmf_example.sdf
@@ -1,0 +1,647 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+	<world name="world">
+		<model name="nmf_example">
+			<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+			<link name="RF_Coxa">
+				<pose>0.35 -0.27 0.4 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RF_Coxa_roll">
+				<pose>0.35 -0.27 0.4 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RF_Coxa_yaw">
+				<pose>0.35 -0.27 0.4 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RF_Femur">
+				<pose>0.35 -0.27 -0.025 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RF_Femur_roll">
+				<pose>0.35 -0.27 -0.025 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RF_Tibia">
+				<pose>0.35 -0.27 -0.731 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RF_Tarsus">
+				<pose>0.35 -0.27 -1.249 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LF_Coxa">
+				<pose>0.35 0.27 0.4 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LF_Coxa_roll">
+				<pose>0.35 0.27 0.4 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LF_Coxa_yaw">
+				<pose>0.35 0.27 0.4 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LF_Femur">
+				<pose>0.35 0.27 -0.025 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LF_Femur_roll">
+				<pose>0.35 0.27 -0.025 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LF_Tibia">
+				<pose>0.35 0.27 -0.731 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LF_Tarsus">
+				<pose>0.35 0.27 -1.249 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RM_Coxa">
+				<pose>0.0 -0.125 0.0 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RM_Coxa_roll">
+				<pose>0.0 -0.125 0.0 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RM_Femur">
+				<pose>0.0 -0.125 -0.182 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RM_Femur_roll">
+				<pose>0.0 -0.125 -0.182 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RM_Tibia">
+				<pose>0.0 -0.125 -0.965 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RM_Tarsus">
+				<pose>0.0 -0.125 -1.633 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LM_Coxa">
+				<pose>0.0 0.125 0.0 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LM_Coxa_roll">
+				<pose>0.0 0.125 0.0 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LM_Femur">
+				<pose>0.0 0.125 -0.182 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LM_Femur_roll">
+				<pose>0.0 0.125 -0.182 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LM_Tibia">
+				<pose>0.0 0.125 -0.965 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LM_Tarsus">
+				<pose>0.0 0.125 -1.633 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RH_Coxa">
+				<pose>-0.215 -0.087 -0.073 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RH_Coxa_roll">
+				<pose>-0.215 -0.087 -0.073 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RH_Femur">
+				<pose>-0.215 -0.087 -0.272 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RH_Femur_roll">
+				<pose>-0.215 -0.087 -0.272 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RH_Tibia">
+				<pose>-0.215 -0.087 -1.108 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RH_Tarsus">
+				<pose>-0.215 -0.087 -1.793 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LH_Coxa">
+				<pose>-0.215 0.087 -0.073 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LH_Coxa_roll">
+				<pose>-0.215 0.087 -0.073 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LH_Femur">
+				<pose>-0.215 0.087 -0.272 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LH_Femur_roll">
+				<pose>-0.215 0.087 -0.272 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LH_Tibia">
+				<pose>-0.215 0.087 -1.108 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LH_Tarsus">
+				<pose>-0.215 0.087 -1.793 0.0 0.0 0.0</pose>
+			</link>
+			<link name="Thorax_mid">
+				<pose>0.08 0.0 1.43 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LF_Claw">
+				<pose>0.35 0.27 -1.912 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RF_Claw">
+				<pose>0.35 -0.27 -1.912 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LM_Claw">
+				<pose>0.0 0.125 -2.328 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RM_Claw">
+				<pose>0.0 -0.125 -2.328 0.0 0.0 0.0</pose>
+			</link>
+			<link name="LH_Claw">
+				<pose>-0.215 0.087 -2.588 0.0 0.0 0.0</pose>
+			</link>
+			<link name="RH_Claw">
+				<pose>-0.215 -0.087 -2.588 0.0 0.0 0.0</pose>
+			</link>
+			<joint name="LF_ThC_yaw">
+				<parent>Thorax_mid</parent>
+				<child>LF_Coxa_yaw</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>1.0 0.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LF_ThC_pitch">
+				<parent>LF_Coxa_yaw</parent>
+				<child>LF_Coxa</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-1.5707963267948966</lower>
+						<upper>1.5707963267948966</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LF_ThC_roll">
+				<parent>LF_Coxa</parent>
+				<child>LF_Coxa_roll</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 0.0 1.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LF_CTr_pitch">
+				<parent>LF_Coxa_roll</parent>
+				<child>LF_Femur</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LF_CTr_roll">
+				<parent>LF_Femur</parent>
+				<child>LF_Femur_roll</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 0.0 1.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LF_FTi_pitch">
+				<parent>LF_Femur_roll</parent>
+				<child>LF_Tibia</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LF_TiTa_pitch">
+				<parent>LF_Tibia</parent>
+				<child>LF_Tarsus</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>0.0</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RF_ThC_yaw">
+				<parent>Thorax_mid</parent>
+				<child>RF_Coxa_yaw</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>1.0 0.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RF_ThC_pitch">
+				<parent>RF_Coxa_yaw</parent>
+				<child>RF_Coxa</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-1.5707963267948966</lower>
+						<upper>1.5707963267948966</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RF_ThC_roll">
+				<parent>RF_Coxa</parent>
+				<child>RF_Coxa_roll</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 0.0 1.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RF_CTr_pitch">
+				<parent>RF_Coxa_roll</parent>
+				<child>RF_Femur</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RF_CTr_roll">
+				<parent>RF_Femur</parent>
+				<child>RF_Femur_roll</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 0.0 1.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RF_FTi_pitch">
+				<parent>RF_Femur_roll</parent>
+				<child>RF_Tibia</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RF_TiTa_pitch">
+				<parent>RF_Tibia</parent>
+				<child>RF_Tarsus</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>0.0</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LM_ThC_yaw">
+				<parent>Thorax_mid</parent>
+				<child>LM_Coxa_yaw</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>1.0 0.0 0.0</xyz>
+					<limit>
+						<lower>-0.8726646259971648</lower>
+						<upper>0.8726646259971648</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LM_ThC_pitch">
+				<parent>LM_Coxa_yaw</parent>
+				<child>LM_Coxa</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LM_ThC_roll">
+				<parent>LM_Coxa</parent>
+				<child>LM_Coxa_roll</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 0.0 1.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>0</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LM_CTr_pitch">
+				<parent>LM_Coxa_roll</parent>
+				<child>LM_Femur</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LM_CTr_roll">
+				<parent>LM_Femur</parent>
+				<child>LM_Femur_roll</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 0.0 1.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LM_FTi_pitch">
+				<parent>LM_Femur_roll</parent>
+				<child>LM_Tibia</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LM_TiTa_pitch">
+				<parent>LM_Tibia</parent>
+				<child>LM_Tarsus</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>0.0</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RM_ThC_yaw">
+				<parent>Thorax_mid</parent>
+				<child>RM_Coxa_yaw</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>1.0 0.0 0.0</xyz>
+					<limit>
+						<lower>-0.8726646259971648</lower>
+						<upper>0.8726646259971648</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RM_ThC_pitch">
+				<parent>RM_Coxa_yaw</parent>
+				<child>RM_Coxa</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RM_ThC_roll">
+				<parent>RM_Coxa</parent>
+				<child>RM_Coxa_roll</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 0.0 1.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>0</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RM_CTr_pitch">
+				<parent>RM_Coxa_roll</parent>
+				<child>RM_Femur</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RM_CTr_roll">
+				<parent>RM_Femur</parent>
+				<child>RM_Femur_roll</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 0.0 1.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RM_FTi_pitch">
+				<parent>RM_Femur_roll</parent>
+				<child>RM_Tibia</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RM_TiTa_pitch">
+				<parent>RM_Tibia</parent>
+				<child>RM_Tarsus</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>0.0</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LH_ThC_yaw">
+				<parent>Thorax_mid</parent>
+				<child>LH_Coxa_yaw</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>1.0 0.0 0.0</xyz>
+					<limit>
+						<lower>-0.8726646259971648</lower>
+						<upper>0.8726646259971648</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LH_ThC_pitch">
+				<parent>LH_Coxa_yaw</parent>
+				<child>LH_Coxa</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-0.8726646259971648</lower>
+						<upper>0.8726646259971648</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LH_ThC_roll">
+				<parent>LH_Coxa</parent>
+				<child>LH_Coxa_roll</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 0.0 1.0</xyz>
+					<limit>
+						<lower>0</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LH_CTr_pitch">
+				<parent>LH_Coxa_roll</parent>
+				<child>LH_Femur</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>0.0</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LH_CTr_roll">
+				<parent>LH_Femur</parent>
+				<child>LH_Femur_roll</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 0.0 1.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LH_FTi_pitch">
+				<parent>LH_Femur_roll</parent>
+				<child>LH_Tibia</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="LH_TiTa_pitch">
+				<parent>LH_Tibia</parent>
+				<child>LH_Tarsus</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>0.0</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RH_ThC_yaw">
+				<parent>Thorax_mid</parent>
+				<child>RH_Coxa_yaw</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>1.0 0.0 0.0</xyz>
+					<limit>
+						<lower>-0.8726646259971648</lower>
+						<upper>0.8726646259971648</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RH_ThC_pitch">
+				<parent>RH_Coxa_yaw</parent>
+				<child>RH_Coxa</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-0.8726646259971648</lower>
+						<upper>0.8726646259971648</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RH_ThC_roll">
+				<parent>RH_Coxa</parent>
+				<child>RH_Coxa_roll</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 0.0 1.0</xyz>
+					<limit>
+						<lower>0</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RH_CTr_pitch">
+				<parent>RH_Coxa_roll</parent>
+				<child>RH_Femur</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>0.0</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RH_CTr_roll">
+				<parent>RH_Femur</parent>
+				<child>RH_Femur_roll</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 0.0 1.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RH_FTi_pitch">
+				<parent>RH_Femur_roll</parent>
+				<child>RH_Tibia</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>3.141592653589793</upper>
+					</limit>
+				</axis>
+			</joint>
+			<joint name="RH_TiTa_pitch">
+				<parent>RH_Tibia</parent>
+				<child>RH_Tarsus</child>
+				<pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+				<axis>
+					<xyz>0.0 1.0 0.0</xyz>
+					<limit>
+						<lower>-3.141592653589793</lower>
+						<upper>0.0</upper>
+					</limit>
+				</axis>
+			</joint>
+		</model>
+	</world>
+</sdf>


### PR DESCRIPTION
Added 
- a test_sdf (generated from the template) in tests/
- a very simple sdf loader in utils
- a sdf parser in example_entire_pipeline and a call to the sdf loader if sdf is given

The sdf parser would read the links and joints to create NMF_TEMPLATE and BOUNDS, which will overwrite the ones loaded from data.py